### PR TITLE
feat: Conventional commits in deploy PR changelog

### DIFF
--- a/.github/actions/changelog/action.yml
+++ b/.github/actions/changelog/action.yml
@@ -1,0 +1,23 @@
+name: Create changelog
+inputs:
+  from-tag:
+    required: true
+    type: string
+  to-tag:
+    required: true
+    type: string
+outputs:
+  changelog:
+    description: "Changelog output body"
+    value: ${{ steps.changelog.outputs.content }}
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - uses: orhun/git-cliff-action@v2
+      id: changelog
+      with:
+        config: fixtures/cliff.toml
+        args: -v ${{ inputs.from-tag }}..${{ inputs.to-tag }}

--- a/.github/workflows/argocd_githash_deploy.yml
+++ b/.github/workflows/argocd_githash_deploy.yml
@@ -127,15 +127,12 @@ jobs:
       - name: Push to ${{ inputs.argocd-branch }} branch
         if: ${{ inputs.make-pr == false }}
         run: git push origin ${{ inputs.argocd-branch }}
-      - name: Get git log
-        if: ${{ inputs.make-pr == true }}
-        id: git-log
-        run: |
-          LOG_MESSAGE=$(git shortlog ${{ steps.previous-version.outputs.previous-version }}..${{ inputs.docker-image-tag }})
-          LOG_MESSAGE="${LOG_MESSAGE//'%'/'%25'}"
-          LOG_MESSAGE="${LOG_MESSAGE//$'\n'/'%0A'}"
-          LOG_MESSAGE="${LOG_MESSAGE//$'\r'/'%0D'}"
-          echo "git-log=$LOG_MESSAGE" >> $GITHUB_OUTPUT
+      - name: Create changelog
+        uses: ./.github/actions/changelog
+        id: changelog
+        with:
+          from-tag: ${{ steps.previous-version.outputs.previous-version }}
+          to-tag: ${{ inputs.docker-image-tag }}
       - name: Create Pull Request
         if: ${{ inputs.make-pr == true }}
         id: pr
@@ -145,12 +142,7 @@ jobs:
           branch: deploy-${{ inputs.environment }}-${{ inputs.app-name }}
           delete-branch: true
           title: "🚀 [${{ inputs.environment }}] ${{ inputs.app-name }} ${{ steps.previous-version.outputs.previous-version }} -> ${{ inputs.docker-image-tag }}"
-          body: |
-            This deployment PR was automatically created by Github Actions.
-
-            ## Changes since last deployment
-
-            ${{ steps.git-log.outputs.git-log }}
+          body: ${{ steps.changelog.outputs.changelog }}
           labels: |
             deployment
             ${{ inputs.app-name }}

--- a/fixtures/cliff.toml
+++ b/fixtures/cliff.toml
@@ -1,0 +1,60 @@
+# configuration file for git-cliff
+# see https://github.com/orhun/git-cliff#configuration-file
+
+[changelog]
+header = ""
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | split(pat="\n") | first | upper_first }} ({{ commit.author.name }})\
+    {% endfor %}
+{% endfor %}\n
+"""
+trim = true
+footer = ""
+
+[git]
+# parse the commits based on https://www.conventionalcommits.org
+conventional_commits = true
+# filter out the commits that are not conventional
+filter_unconventional = false
+# process each line of a commit as an individual commit
+split_commits = false
+# regex for preprocessing the commit messages
+commit_preprocessors = [
+    { pattern = "^Merge pull request #([0-9]+) .*", replace = "PR #${1}"}
+]
+# regex for parsing and grouping commits
+commit_parsers = [
+    { message = "^feat", group = "Features"},
+    { message = "^fix", group = "Bug Fixes"},
+    { message = "^doc", group = "Documentation"},
+    { message = "^perf", group = "Performance"},
+    { message = "^refactor", group = "Refactor"},
+    { message = "^style", group = "Styling"},
+    { message = "^test", group = "Testing"},
+    { message = "^ci", group = "CI"},
+    { message = "^chore\\(release\\): prepare for", skip = true},
+    { message = "^chore", group = "Miscellaneous Tasks"},
+    { body = ".*security", group = "Security"},
+    { message = "^PR", group = "Pull Requests"},
+    { message = ".*", group = "Other"},
+]
+# protect breaking changes from being skipped due to matching a skipping commit_parser
+protect_breaking_commits = false
+# filter out the commits that are not matched by commit parsers
+filter_commits = true
+# glob pattern for matching git tags
+tag_pattern = "v[0-9]*"
+# regex for skipping tags
+skip_tags = "v0.1.0-beta.1"
+# regex for ignoring tags
+ignore_tags = ""
+# sort the tags topologically
+topo_order = false
+# sort the commits inside sections by oldest/newest order
+sort_commits = "oldest"


### PR DESCRIPTION
This uses [git-cliff](https://github.com/orhun/git-cliff) and [git-cliff-action](https://github.com/orhun/git-cliff-action) to produce a nicely formatting changelog output.

I added a wrapper workflow for git-cliff-action in order to inject a cliff.toml config file in so that we can share formatting config across projects (though this could also be updated to be overridden on a per-project basis if needed)

# Example output

### Bug Fixes

- FBQA MSE-3477 add mising ad optimization options (Andrew Sosa)

### Features

- MSE-3496 - Utilize Ad Assignments sheet treat is as a first-party QA Check. (Omar Ali Khan)
- AMC task which cleans out specific AMC folders in google drive. (DanCardin)
- Isolate PANDL emails into their own folder in S3. (Omar Ali Khan)
- FBQA use campaign/adset column instead of just filtering to active (Andrew Sosa)
- MSE-3518 FBQA Stop checking attribution spec (Andrew Sosa)

### Other

- Make Roku log Creative Name nullable (Steven Rohr)
- Update CM360 API to v4 (Steven Rohr)
- Disallow null Creative Names in AMC Roku logs (Steven Rohr)
- Update platform-actions/src/platform_actions/cli/advertiser/amc.py (Steven Rohr)

### Pull Requests

- PR #2940 (Steven Rohr)
- PR #2937 (Omar Ali Khan)
- PR #2942 (Steven Rohr)
- PR #2943 (DanCardin)
- PR #2944 (Steven Rohr)
- PR #2949 (Omar Ali Khan)
- PR #2947 (Andrew Sosa)
- PR #2950 (Andrew Sosa)
- PR #2951 (Andrew Sosa)