### PR TITLE
Update publish_schireson_artifactory.yml

### DIFF
--- a/.github/workflows/publish_schireson_artifactory.yml
+++ b/.github/workflows/publish_schireson_artifactory.yml
@@ -60,4 +60,4 @@ jobs:
           poetry build
           poetry publish -n --repository schireson 2>&1 | tee publish.log || true
           OUTPUT=$(tail -n 1 publish.log)
-          grep -vq 'HTTP Error' <<< $OUTPUT || grep -q 'HTTP Error 404' <<< $OUTPUT
+          grep -vq 'HTTP Error' <<< $OUTPUT || grep -q 'HTTP Error 404' <<< $OUTPUT || grep -q 'HTTP Error 400' <<< $OUTPUT


### PR DESCRIPTION
Meant to make our main branch CI indicator stop being red when it's not really: https://github.com/schireson/afterburner/actions/runs/7820492688/job/21335337239 